### PR TITLE
drop deprecated things in airflow 2

### DIFF
--- a/src/airflow_fs/hooks/fs_hook.py
+++ b/src/airflow_fs/hooks/fs_hook.py
@@ -16,7 +16,7 @@ class FsHook(BaseHook):
     """
 
     def __init__(self):
-        super().__init__(source=None)
+        super().__init__()
 
     def __enter__(self):
         return self

--- a/src/airflow_fs/operators.py
+++ b/src/airflow_fs/operators.py
@@ -3,7 +3,7 @@
 import posixpath
 
 from airflow.models import BaseOperator
-from airflow.utils import apply_defaults
+from airflow.utils.decorators import apply_defaults
 
 from airflow_fs.hooks.local_hook import LocalHook
 from airflow_fs.ports import glob


### PR DESCRIPTION
1) the `apply_default` decorator is not hoisted to `airflow.utils` and it needs to be imported directly from `airflow.utils.decorators`
2) `source` parameter is not longer present in `BaseHook`